### PR TITLE
Added loading-class to autocomplete while fetching results

### DIFF
--- a/src/main/java/org/vaadin/addons/autocomplete/client/AutocompleteExtensionConnector.java
+++ b/src/main/java/org/vaadin/addons/autocomplete/client/AutocompleteExtensionConnector.java
@@ -90,6 +90,8 @@ public class AutocompleteExtensionConnector extends AbstractExtensionConnector {
                         } else {
                             suggestionList.hide();
                         }
+
+                        wrapper.removeClassName("autocomplete-loading");
                     }
 
                     @Override
@@ -223,6 +225,11 @@ public class AutocompleteExtensionConnector extends AbstractExtensionConnector {
     }
 
     private void showSuggestionsFor(String text, int delayMillis) {
+        if (text.equals("")) {
+            wrapper.removeClassName("autocomplete-loading");
+        } else {
+            wrapper.addClassName("autocomplete-loading");
+        }
         suggestionTimer.schedule(text, suggestionList.getQuery(), delayMillis);
     }
 


### PR DESCRIPTION
Hi,
i needed some kind of loading-indicator for the autocomplete-textfield so i added the changes in this commit. Its just a simple css-class so one can add it's own styling (loading-gif, changed color, etc.). 

If you are okay with the changes, maybe you can accept the PR and release a new version in the vaadin-directory with it?

Greetings
Andre